### PR TITLE
クエリの追加・修正とそれに伴う修正

### DIFF
--- a/app/assets/vue/index.vue
+++ b/app/assets/vue/index.vue
@@ -17,26 +17,108 @@
       YearlyChart
     }
   }
+
   /**
-   * APIを用い指定した日付からの鍵の情報を取得
-   * @param first_date{Date} -  get from this param
+   * APIを用い指定した日付の週の鍵の情報を取得
+   * @param date{Date} -  get information this param week　
    * @return {Promise} - Promise object
    */
-  function GetStatistics(first_date){
-    return new Promise(function(resolve,reject){
+  function GetStatistics_Week(date){
+    return new Promise(function(resolve, reject){
       const url = "https://key-notify-server.herokuapp.com/api/statistics"
-      let from_date = new Date(first_date.getTime())
+      let from_date = new Date(date.getTime())
+      let by_date = new Date(date.getTime())
       let request = new XMLHttpRequest()
       // format Date
       if(from_date.getDay() != 0){
         from_date.setDate(from_date.getDate() - from_date.getDay())
       }
-      let month = from_date.getMonth() + 1
-      if(month <= 9){
-        month = "0" + month
+      if(by_date.getDay() != 6){
+        by_date.setDate(by_date.getDate() (6 - from_date.getDay()))
       }
-      let url_param = url + "?first_date=" + from_date.getFullYear() + "-" + month + "-" + from_date.getDate() + " 00:00:00"
-      console.log(url_param)
+      let from_month = from_date.getMonth() + 1
+      if(from_month <= 9){
+        from_month = "0" + from_month
+      }
+      let by_month = by_date.getMonth() + 1
+      if(by_month <= 9){
+        by_month = "0" + by_month
+      }
+      let from_day = from_date.getDate()
+      if(from_day <= 9){
+        from_day = "0" + from_day
+      }
+      let by_day = by_date.getDate()
+      if(by_day <= 9){
+        by_day = "0" + by_day
+      }
+      let url_param = url + "?first_date=" + from_date.getFullYear() + "-" + from_month + "-" + from_day + " 00:00:00&end_date=" + by_date.getFullYear() + "-" + by_month + "-" + by_day + " 23:59:59"
+      // send request
+      request.responseType = 'json'
+      request.open("GET", url_param)
+      request.addEventListener("load", (event) => {
+        // get server error
+        if(event.target.status != 200){
+          reject()
+        } else {
+          resolve(event.target.response)
+        }
+      })
+      // get connect error
+      request.addEventListener("error", () => {
+        reject()
+      })
+      request.send()
+    })
+  }
+
+  /**
+   * APIを用い指定した日付の年度の鍵の情報を取得
+   * @param date{Date} -  get information this param fiscal　year
+   * @return {Promise} - Promise object
+   */
+  function GetStatistics_Year(date){
+    return new Promise(function(resolve, reject){
+      const url = "https://key-notify-server.herokuapp.com/api/statistics"
+      let from_date = new Date(date.getTime())
+      let by_date = new Date(date.getTime())
+      let request = new XMLHttpRequest()
+      // form from month
+      if(from_date.getMonth() > 3){
+        from_date.setMonth(from_date.getMonth() - (from_date.getMonth() - 3))
+      } else if (from_date.getMonth() < 3) {
+        from_date.setMonth(from_date.getMonth() + (3 - from_date.getMonth()))
+        from_date.setYear(from_date.getFullYear() - 1)
+      }
+      // form by month
+      if(by_date.getMonth() > 2){
+        by_date.setMonth(by_date.getMonth() - (by_date.getMonth() - 2))
+        by_date.setYear(by_date.getFullYear() + 1)
+      } else if (by_date.getMonth() < 2) {
+        by_date.setMonth(by_date.getMonth() + (2 - by_date.getMonth()))
+      }
+      // set from day
+      from_date.setDate(1)
+      if(from_date.getDay() != 0){
+        from_date.setDate(from_date.getDate() - from_date.getDay())
+      }
+      // set by day
+      by_date.setDate(31)
+      if(by_date.getDay() != 6){
+        by_date.setDate(by_date.getDate() - (by_date.getDay() + 1))
+      }
+      // form url
+      let from_month = from_date.getMonth() + 1
+      let by_month = by_date.getMonth() + 1
+      let from_day = from_date.getDate()
+      if(from_day <= 9){
+        from_day = "0" + from_day
+      }
+      let by_day = by_date.getDate()
+      if(by_day <= 9){
+        by_day = "0" + by_day
+      }
+      let url_param = url + "?first_date=" + from_date.getFullYear() + "-0" + from_month + "-" + from_day + " 00:00:00&end_date=" + by_date.getFullYear() + "-0" + by_month + "-" + by_day + " 23:59:59"
       // send request
       request.responseType = 'json'
       request.open("GET", url_param)

--- a/app/assets/vue/index.vue
+++ b/app/assets/vue/index.vue
@@ -20,7 +20,7 @@
 
   /**
    * APIを用い指定した日付の週の鍵の情報を取得
-   * @param date{Date} -  get information this param week　
+   * @param date{Date} -  get information this param week
    * @return {Promise} - Promise object
    */
   function GetStatistics_Week(date){
@@ -30,11 +30,9 @@
       let by_date = new Date(date.getTime())
       let request = new XMLHttpRequest()
       // format Date
-      if(from_date.getDay() != 0){
-        from_date.setDate(from_date.getDate() - from_date.getDay())
-      }
+      from_date.setDate(from_date.getDate() - from_date.getDay())
       if(by_date.getDay() != 6){
-        by_date.setDate(by_date.getDate() (6 - from_date.getDay()))
+        by_date.setDate(by_date.getDate() + (6 - from_date.getDay()))
       }
       let from_month = from_date.getMonth() + 1
       if(from_month <= 9){
@@ -74,7 +72,7 @@
 
   /**
    * APIを用い指定した日付の年度の鍵の情報を取得
-   * @param date{Date} -  get information this param fiscal　year
+   * @param date{Date} -  get information this param fiscal year
    * @return {Promise} - Promise object
    */
   function GetStatistics_Year(date){
@@ -99,9 +97,7 @@
       }
       // set from day
       from_date.setDate(1)
-      if(from_date.getDay() != 0){
-        from_date.setDate(from_date.getDate() - from_date.getDay())
-      }
+      from_date.setDate(from_date.getDate() - from_date.getDay())
       // set by day
       by_date.setDate(31)
       if(by_date.getDay() != 6){

--- a/sql_query/sql_query.go
+++ b/sql_query/sql_query.go
@@ -50,14 +50,56 @@ func Get_all_statistics() ([]Key_info, error){
   return info_array, nil
 }
 
-/* 統計データ指定日時から最新まで抽出
- * fd: time.Time 取得する統計値の指定日時
+/* 統計データ指定日時から指定日時まで抽出
+ * fd: time.Time 統計値の取得を開始する指定日時
+ * ed: time.Time 統計値の取得を終わる指定日時
 */
-func Get_statistics(fd time.Time) ([]Key_info, error){
-  form_time := fd.Format("2006-01-02 15:04:05")
-  rows, err := db.Query("SELECT * FROM key_info WHERE time >= ? ORDER BY time DESC", form_time)
+func Get_statistics(fd time.Time,ed time.Time) ([]Key_info, error){
+  first_time := fd.Format("2006-01-02 15:04:05")
+  end_time := ed.Format("2006-01-02 15:04:05")
+  rows, err := db.Query("SELECT * FROM key_info WHERE time >= ? AND time <= ? ORDER BY time DESC", first_time, end_time)
   if err != nil {
     return nil, err
+  }
+  var info_array []Key_info
+  defer rows.Close()
+  for rows.Next() {
+    var info Key_info
+    if err := rows.Scan(&info.Time, &info.State, &info.Key_info_id); err != nil {
+      return nil, err
+    }
+    info_array = append(info_array, info)
+  }
+  return info_array, nil
+}
+
+/* 最新データ一件を抽出
+*/
+func Get_latest_state() ([]Key_info, error){
+  rows, err := db.Query("SELECT * FROM key_info ORDER BY time DESC LIMIT 1")
+  if err != nil {
+    return nil , err
+  }
+  var info_array []Key_info
+  defer rows.Close()
+  for rows.Next() {
+    var info Key_info
+    if err := rows.Scan(&info.Time, &info.State, &info.Key_info_id); err != nil {
+      return nil, err
+    }
+    info_array = append(info_array, info)
+  }
+  return info_array, nil
+}
+
+/* 指定した日時の一つ前のデータを抽出
+ * fd: time.Time 取得する値の指定日時
+*/
+func Get_before_state(fd time.Time) ([]Key_info, error){
+  form_time := fd.Format("2006-01-02 15:04:05")
+  rows, err := db.Query("SELECT * FROM key_info WHERE time <= ? ORDER BY time DESC LIMIT 1", form_time)
+  if err != nil {
+    return nil , err
   }
   var info_array []Key_info
   defer rows.Close()

--- a/sql_query/sql_query.go
+++ b/sql_query/sql_query.go
@@ -57,7 +57,7 @@ func Get_all_statistics() ([]Key_info, error){
 func Get_statistics(fd time.Time,ed time.Time) ([]Key_info, error){
   first_time := fd.Format("2006-01-02 15:04:05")
   end_time := ed.Format("2006-01-02 15:04:05")
-  rows, err := db.Query("SELECT * FROM key_info WHERE time >= ? AND time <= ? ORDER BY time DESC", first_time, end_time)
+  rows, err := db.Query("SELECT * FROM key_info WHERE time >= ? AND time <= ? ORDER BY time", first_time, end_time)
   if err != nil {
     return nil, err
   }

--- a/sql_query/sql_query.go
+++ b/sql_query/sql_query.go
@@ -33,7 +33,7 @@ func init(){
 /* 統計データ全件抽出
 */
 func Get_all_statistics() ([]Key_info, error){
-  rows, err := db.Query("SELECT * FROM key_info")
+  rows, err := db.Query("SELECT * FROM key_info ORDER BY time")
   if err != nil {
     return nil, err
   }


### PR DESCRIPTION
## やったこと
* 一番最近のstate1件を抽出するクエリの追加
* 一番最近のstate1件を取得するAPIの追加
* 指定の日時より一番近くて早いものを抽出するクエリの追加
* 指定の日時より一番近くて早いものを取得するAPIの追加
* /api/statisticsのend_date指定の追加
* API仕様変更に伴うAPI使用箇所の修正
* 指定した日付の年度の鍵情報を取得する処理の追加

## やらなかったこと
* 特になし