### PR TITLE
グラフのデータラベル追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Yuri Mizushima, Amano Takumi
+Copyright (c) 2018 Yuri Mizushima, amataku
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/app/assets/less/main.less
+++ b/app/assets/less/main.less
@@ -5,7 +5,7 @@
 @title-back-color: #95A5A6;
 @article-back-color: #ECF0F1;
 @state-on-color: #27AE60;
-@state-off-color: #E74C3C;
+@state-off-color: @back-color;
 @text-white-color: #FFFFFF;
 @text-black-color: @theme-color;
 

--- a/app/assets/vue/footer.vue
+++ b/app/assets/vue/footer.vue
@@ -1,7 +1,7 @@
 <template>
   <footer id="footer">
     <p>
-      Copyright (c) 2018 <a href="https://github.com/equanz">Yuri Mizushima</a>, <a href="https://github.com/amataku">Amano Takumi</a>
+      Copyright (c) 2018 <a href="https://github.com/equanz">Yuri Mizushima</a>, <a href="https://github.com/amataku">amataku</a>
     </p>
   </footer>
 </template>

--- a/app/assets/vue/weekly_chart.vue
+++ b/app/assets/vue/weekly_chart.vue
@@ -14,10 +14,18 @@
               ticks: {
                 beginAtZero: true,
                 max: 24 // max value in x-axes
+              },
+              scaleLabel: {
+                display: true,
+                labelString: "date[hours]"
               }
             }],
             yAxes: [{
-              stacked: true
+              stacked: true,
+              scaleLabel: {
+                display: true,
+                labelString: "day"
+              }
             }]
           },
           tooltips: {

--- a/app/assets/vue/yearly_chart.vue
+++ b/app/assets/vue/yearly_chart.vue
@@ -8,12 +8,26 @@
     data() {
       return {
         options: { // options
+          scales: {
+            xAxes: [{
+              scaleLabel: {
+                display: true,
+                labelString: "date[months]"
+              }
+            }],
+            yAxes: [{
+              scaleLabel: {
+                display: true,
+                labelString: "active time[hours]"
+              }
+            }]
+          },
           tooltips: {
             enabled: false
           },
-          legend: {
-            display: false
-          }
+                   legend: {
+                     display: false
+                   }
         }
       }
     },

--- a/app/assets/vue/yearly_chart.vue
+++ b/app/assets/vue/yearly_chart.vue
@@ -25,9 +25,9 @@
           tooltips: {
             enabled: false
           },
-                   legend: {
-                     display: false
-                   }
+          legend: {
+            display: false
+          }
         }
       }
     },


### PR DESCRIPTION
### やったこと
* グラフ各軸へのラベル追加
  - ラベルに単位を表記
* ステータスカラー変更
  - グラフとステータス表示で状態を表す色を統一
    - ON: `#27AE60`
    - OFF: `#BDC3C7`
* ライセンスでのクレジット修正
  - GitHubアカウントの設定変更に伴い変更

### やらないこと
* グラフへの凡例表示
