### PR TITLE
CI側のDockerイメージ元変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     # Set Docker image
     docker:
-      - image: equanz/golang-alpine-node:1.8.5
+      - image: equanz/key-notify-server
     working_directory: /go/src/github.com/equanz/key-notify-server
 
     steps:


### PR DESCRIPTION
### やったこと
* CI側のDockerイメージ元変更
  - `key-notify-server` 側のビルド済みイメージに変更

### やらないこと
特に無し
